### PR TITLE
Change AFNetworking import for compatability with projects with modules

### DIFF
--- a/ios/ios/src/Web Services/CMWebService.h
+++ b/ios/ios/src/Web Services/CMWebService.h
@@ -8,13 +8,14 @@
 
 /** @file */
 
-#import "AFNetworking.h"
 #import "CMFileUploadResult.h"
 #import "CMDeviceTokenResult.h"
 #import "CMUserAccountResult.h"
 #import "CMSocialLoginViewController.h"
 #import "CMChannelResponse.h"
 #import "CMViewChannelsResponse.h"
+
+#import <AFNetworking/AFNetworking.h>
 
 @class CMUser;
 @class CMServerFunction;


### PR DESCRIPTION
Of particular interest, this single change allows the CloudMine SDK to be imported into Swift projects without a bridging header, but using normal Swift import directives:

```Swift
import UIKit
import CloudMine
```
