### PR TITLE
Push Notification Registration Method Updates

### DIFF
--- a/ios/ios/src/Storage/CMStore.h
+++ b/ios/ios/src/Storage/CMStore.h
@@ -201,7 +201,7 @@ extern NSString * const CMStoreObjectDeletedNotification;
  *
  *  @see -registerForPushNotificationTypes:callback:
  */
-- (void)registerForPushNotifications:(UIRemoteNotificationType)notificationType callback:(CMWebServiceDeviceTokenCallback)callback __deprecated_msg("instead use -registerForPushNotificationTypes:callback:");
+- (void)registerForPushNotifications:(NSInteger)notificationType callback:(CMWebServiceDeviceTokenCallback)callback __deprecated_msg("instead use -registerForPushNotificationTypes:callback:");
 
 
 /**

--- a/ios/ios/src/Storage/CMStore.h
+++ b/ios/ios/src/Storage/CMStore.h
@@ -237,6 +237,17 @@ extern NSString * const CMStoreObjectDeletedNotification;
  */
 - (void)registerForPushNotifications:(NSInteger)notificationType user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
 
+
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes callback:(CMWebServiceDeviceTokenCallback)callback;
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationType
+                              categories:(NSSet <UIUserNotificationCategory *>*)categories
+                                    user:(CMUser *)aUser
+                                callback:(CMWebServiceDeviceTokenCallback)callback;
+
 /**
  * Unregisters the users token from CloudMine, so they will no longer receive push notifications. Recommended to remove the token when
  * the user logs out of the app, but not required.

--- a/ios/ios/src/Storage/CMStore.h
+++ b/ios/ios/src/Storage/CMStore.h
@@ -195,54 +195,71 @@ extern NSString * const CMStoreObjectDeletedNotification;
 - (instancetype)initWithUser:(CMUser *)theUser baseURL:(NSString *)url;
 
 /**
- * Registers your application for push notifications. This method will contact Apple, request a token, handle the token
- * and register your application with CloudMine. After the token has been sent to Cloudmine, the callback with the result
- * will be given.
+ *  Registers you application for push notifications.
  *
- * <strong>Note</strong> - This method will register the stored CMUser to the token. If you do not want to associate the token with the user use
- * registerForPushNotifications:user:callback: and pass nil.
+ *  @warning Deprecated. This method's first parameter is a bit mask of UIRemoteNotificationType type, which has been deprecated by Apple.
  *
- * @param notificationType The parameter of this method takes a UIRemoteNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, <tt>(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound)</tt>
- * @param callback Can be nil - The callback which is called once the Token has been sent to Cloudmine, returns the result of that transaction.
+ *  @see -registerForPushNotificationTypes:callback:
  */
-- (void)registerForPushNotifications:(UIRemoteNotificationType)notificationType callback:(CMWebServiceDeviceTokenCallback)callback;
+- (void)registerForPushNotifications:(UIRemoteNotificationType)notificationType callback:(CMWebServiceDeviceTokenCallback)callback __deprecated_msg("instead use -registerForPushNotificationTypes:callback:");
+
 
 /**
- * Registers your application for push notifications. This method will contact Apple, request a token, handle the token
- * and register your application with CloudMine. After the token has been sent to Cloudmine, the callback with the result
- * will be given.
+ *  Registers you application for push notifications.
  *
- * <strong>Note</strong> - This method will register the stored CMUser to the token. If you do not want to associate the token with the user use
- * registerForPushNotifications:user:callback: and pass nil.
+ *  @warning Deprecated. This method's first parameter is a bit mask of UIRemoteNotificationType type, which has been deprecated by Apple.
  *
- * @param notificationType The parameter of this method takes a UIRemoteNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, <tt>(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound)</tt>
- * @param categories The categories that will be submitted to the call. iOS 8 only (Ignored in lower versions of iOS).
- * @param aUser - The user to which this call will be made with.
- * @param callback Can be nil - The callback which is called once the Token has been sent to Cloudmine, returns the result of that transaction.
+ *  @see -registerForPushNotificationTypes:categories:user:callback
  */
 - (void)registerForPushNotifications:(NSInteger)notificationType
                           categories:(NSSet *)categories
                                 user:(CMUser *)aUser
-                            callback:(CMWebServiceDeviceTokenCallback)callback;
+                            callback:(CMWebServiceDeviceTokenCallback)callback __deprecated_msg("instead user -registerForPushNotificationTypes:categories:user:callback:");
+
+/**
+ *  Registers you application for push notifications.
+ *
+ *  @warning Deprecated. This method's first parameter is a bit mask of UIRemoteNotificationType type, which has been deprecated by Apple.
+ *
+ *  @see -registerForPushNotificationTypes:user:callback
+ */
+- (void)registerForPushNotifications:(NSInteger)notificationType user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback __deprecated_msg("instead use registerForPushNotificationTypes:user:callback:");
 
 /**
  * Registers your application for push notifications. This method will contact Apple, request a token, handle the token
- * and register your application with CloudMine. After the token has been sent to Cloudmine, the callback with the result
+ * and register your application with CloudMine. After the token has been sent to CloudMine, the callback with the result
+ * will be given.
+ *
+ * <strong>Note</strong> - This method will register the stored CMUser to the token. If you do not want to associate the token with the user use
+ * registerForPushNotificationTypes:user:callback: and pass nil.
+ *
+ * @param notificationType The parameter of this method takes a UIUserNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, Alert, Badge, and Sound.
+ * @param callback Can be nil. The callback which is called once the Token has been sent to CloudMine, returns the result of that transaction.
+ */
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes callback:(CMWebServiceDeviceTokenCallback)callback;
+
+/**
+ * Registers your application for push notifications. This method will contact Apple, request a token, handle the token
+ * and register your application with CloudMine. After the token has been sent to CloudMine, the callback with the result
  * will be given.
  *
  *
- * @param notificationType The parameter of this method takes a UIRemoteNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, <tt>(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound)</tt>
- * @param user Can be nil. The user you want to associate the token with.
- * @param callback Can be nil - The callback which is called once the Token has been sent to Cloudmine, returns the result of that transaction.
+ * @param notificationType The parameter of this method takes a UIUserNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, Alert, Badge, and Sound.
+ * @param user The user you want to associate the token with.
+ * @param callback Can be nil. The callback which is called once the Token has been sent to Cloudmine, returns the result of that transaction.
  */
-- (void)registerForPushNotifications:(NSInteger)notificationType user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
-
-
-
-- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes callback:(CMWebServiceDeviceTokenCallback)callback;
-
 - (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
 
+/**
+ * Registers your application for push notifications. This method will contact Apple, request a token, handle the token
+ * and register your application with CloudMine. After the token has been sent to CloudMine, the callback with the result
+ * will be given.
+ *
+ * @param notificationType The parameter of this method takes a UIUserNotificationType bit mask that specifies the initial types of notifications that the application wishes to receive. For example, Alert, Badge, and Sound.
+ * @param categories The categories that will be submitted to the call.
+ * @param aUser The user to which this call will be made with.
+ * @param callback Can be nil. The callback which is called once the Token has been sent to Cloudmine, returns the result of that transaction.
+ */
 - (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationType
                               categories:(NSSet <UIUserNotificationCategory *>*)categories
                                     user:(CMUser *)aUser
@@ -252,7 +269,7 @@ extern NSString * const CMStoreObjectDeletedNotification;
  * Unregisters the users token from CloudMine, so they will no longer receive push notifications. Recommended to remove the token when
  * the user logs out of the app, but not required.
  *
- * @param callback Can be nil - The callback which is called once the Token has been removed fromCloudmine, returns the result of that transaction.
+ * @param callback Can be nil - The callback which is called once the Token has been removed from CloudMine, returns the result of that transaction.
  */
 - (void)unRegisterForPushNotificationsWithCallback:(CMWebServiceDeviceTokenCallback)callback;
 

--- a/ios/ios/src/Storage/CMStore.m
+++ b/ios/ios/src/Storage/CMStore.m
@@ -229,7 +229,7 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
 
 // DEPRECATED: Remove in next version bump
 
-- (void)registerForPushNotifications:(UIRemoteNotificationType)notificationType callback:(CMWebServiceDeviceTokenCallback)callback;
+- (void)registerForPushNotifications:(NSInteger)notificationType callback:(CMWebServiceDeviceTokenCallback)callback;
 {
     [self registerForPushNotifications:notificationType user:self.user callback:callback];
 }
@@ -241,6 +241,11 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
 
 - (void)registerForPushNotifications:(NSInteger)notificationType categories:(NSSet *)categories user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
 {
+    // Technically there is an implicit "cast" going on here form the deprecated `UIRemoteNotificationType` bit mask to the
+    // new `UIUserNotificationType` bit mask. This is extremely ill advised, but it's what the SDK was already doing by detecting
+    // the OS version and using the same `notificationType` variable. The reason we're getting away with it is because Apple
+    // (mercifully) defined the values in the new bitmask to align with the old one. So this works, and we should drop these methods
+    // in the next version after developers have had a chance to see the deprecation warnings popping up.
     [self registerForPushNotificationTypes:notificationType user:user callback:callback];
 }
 

--- a/ios/ios/src/Storage/CMStore.m
+++ b/ios/ios/src/Storage/CMStore.m
@@ -227,6 +227,8 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
 
 #pragma mark - Push Notifications
 
+// DEPRECATED: Remove in next version bump
+
 - (void)registerForPushNotifications:(UIRemoteNotificationType)notificationType callback:(CMWebServiceDeviceTokenCallback)callback;
 {
     [self registerForPushNotifications:notificationType user:self.user callback:callback];
@@ -239,9 +241,26 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
 
 - (void)registerForPushNotifications:(NSInteger)notificationType categories:(NSSet *)categories user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback;
 {
+    [self registerForPushNotificationTypes:notificationType user:user callback:callback];
+}
+
+// UPDATED
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes callback:(CMWebServiceDeviceTokenCallback)callback
+{
+    [self registerForPushNotificationTypes:notificationTypes user:self.user callback:callback];
+}
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback
+{
+    [self registerForPushNotificationTypes:notificationTypes categories:nil user:aUser callback:callback];
+}
+
+- (void)registerForPushNotificationTypes:(UIUserNotificationType)notificationTypes categories:(NSSet <UIUserNotificationCategory *>*)categories user:(CMUser *)aUser callback:(CMWebServiceDeviceTokenCallback)callback
+{
     NSAssert([[[UIApplication sharedApplication] delegate] isKindOfClass:[CMAppDelegateBase class]], @"Your Application Delegate MUST Inherit for CMAppDelegateBase in order to register for push notifications in this way!\n \
              If you do not want to inherit from CMAppDelegateBase, you will need to use [CMWebService registerForPushNotificationsWithUser:deviceToken:callback:]");
-    
+
     if (!aUser.isLoggedIn) {
         NSLog(@"*** CLOUDMINE: Attempting to register for push notifications requires a user that is logged in! The user is either not logged in, or nil!");
         if (callback) {
@@ -249,20 +268,15 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
         }
         return;
     }
-    
+
     CMAppDelegateBase *delegate = [[UIApplication sharedApplication] delegate];
     delegate.callback = callback;
     delegate.user = aUser;
     delegate.service = self.webService;
-    
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:notificationType categories:categories];
-        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    }
-    else {
-        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationType];
-    }
+
+    UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:notificationTypes categories:categories];
+    [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
 - (void)unRegisterForPushNotificationsWithCallback:(CMWebServiceDeviceTokenCallback)callback;

--- a/ios/iosTests/CMStoreSpec.m
+++ b/ios/iosTests/CMStoreSpec.m
@@ -448,7 +448,7 @@ describe(@"CMStore", ^{
             });
             
             it(@"should assert that the delegate is a CMAppBase", ^{
-                [[theBlock(^{ [store registerForPushNotifications:0 callback:nil]; }) should] raise];
+                [[theBlock(^{ [store registerForPushNotificationTypes:UIUserNotificationTypeAlert callback:nil]; }) should] raise];
             });
             
             it(@"should let the user unregister for push notifications", ^{


### PR DESCRIPTION
In iOS 8, Apple deprecated existing methods for registering for push notifications. This pull request updates our interfaces to use the new methods and types, and marks the existing methods as deprecated. Also, because the SDK now targets iOS 8 and above, we are able to remove code that detected OS version and used different APIs depending on that version. This update removes several build warnings.