### PR TITLE
Tests Cleanup

### DIFF
--- a/ios/cloudmine-ios.xcodeproj/project.pbxproj
+++ b/ios/cloudmine-ios.xcodeproj/project.pbxproj
@@ -188,7 +188,6 @@
 		AAE92211194B923D004DA1AC /* CMWebServiceIntegrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AAE92210194B923D004DA1AC /* CMWebServiceIntegrationSpec.m */; };
 		AAFB0B8D194B45D5008F2B68 /* CMResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AAFB0B8C194B45D5008F2B68 /* CMResponseSpec.m */; };
 		B4AD7C521C80FF6D00D9F1D1 /* MARTNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C461C80FF6C00D9F1D1 /* MARTNSObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B4AD7C531C80FF6D00D9F1D1 /* README.markdown in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C471C80FF6C00D9F1D1 /* README.markdown */; };
 		B4AD7C541C80FF6D00D9F1D1 /* RTIvar.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C491C80FF6C00D9F1D1 /* RTIvar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B4AD7C551C80FF6D00D9F1D1 /* RTMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C4B1C80FF6C00D9F1D1 /* RTMethod.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B4AD7C561C80FF6D00D9F1D1 /* RTProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C4D1C80FF6C00D9F1D1 /* RTProperty.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -1207,7 +1206,6 @@
 				B4AD7C581C80FF6D00D9F1D1 /* RTUnregisteredClass.m in Sources */,
 				7A58CC2214F1B544003E864B /* CMMimeType.m in Sources */,
 				7AE2848B1562C3C8003E8A8F /* CMSortDescriptor.m in Sources */,
-				B4AD7C531C80FF6D00D9F1D1 /* README.markdown in Sources */,
 				65199EC2156A7D9500267EC6 /* CMDeleteResponse.m in Sources */,
 				65199EC3156A7D9500267EC6 /* CMFileFetchResponse.m in Sources */,
 				65199EC4156A7D9500267EC6 /* CMFileUploadResponse.m in Sources */,

--- a/ios/ios/src/Web Services/CMSocialAccountChooser.m
+++ b/ios/ios/src/Web Services/CMSocialAccountChooser.m
@@ -22,13 +22,13 @@
 {
     self.callback = callback;
     
+#if TESTING==0
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:nil
                                                     message:@"Twitter access not granted, would you like to login with another Twitter account?"
                                                    delegate:self
                                           cancelButtonTitle:@"No"
                                           otherButtonTitles:@"Yes", nil];
     
-#if TESTING==0
     dispatch_async(dispatch_get_main_queue(), ^{
         [alert show];
     });

--- a/ios/iosTests/CMAppDelegateBaseSpec.m
+++ b/ios/iosTests/CMAppDelegateBaseSpec.m
@@ -51,7 +51,7 @@ describe(@"CMAppDelegateBase", ^{
     
     it(@"should response to a failure to register", ^{
         NSError *error = [NSError errorWithDomain:@"example" code:-100 userInfo:@{@"info": @"moreinfo"}];
-        [base application:nil didFailToRegisterForRemoteNotificationsWithError:error];
+        [base application:[UIApplication sharedApplication] didFailToRegisterForRemoteNotificationsWithError:error];
     });
     
 });

--- a/ios/iosTests/CMSocialAccountChooserSpec.m
+++ b/ios/iosTests/CMSocialAccountChooserSpec.m
@@ -25,7 +25,7 @@ describe(@"CMSocialAccountChooser", ^{
             [[account should] beNil];
         }];
         
-        [chooser actionSheet:nil clickedButtonAtIndex:2];
+        [chooser actionSheet:[UIActionSheet new] clickedButtonAtIndex:2];
     });
     
     it(@"should return a NSNumber when 'Another Account' is tapped", ^{
@@ -35,7 +35,7 @@ describe(@"CMSocialAccountChooser", ^{
             [[account should] beKindOfClass:[NSNumber class]];
         }];
         
-        [chooser actionSheet:nil clickedButtonAtIndex:1];
+        [chooser actionSheet:[UIActionSheet new] clickedButtonAtIndex:1];
     });
     
     it(@"should return the account when tapped", ^{
@@ -45,7 +45,7 @@ describe(@"CMSocialAccountChooser", ^{
             [[account should] beKindOfClass:[ACAccount class]];
         }];
         
-        [chooser actionSheet:nil clickedButtonAtIndex:0];
+        [chooser actionSheet:[UIActionSheet new] clickedButtonAtIndex:0];
     });
     
     it(@"should popup a uialert view (if it could) and say no", ^{
@@ -54,7 +54,7 @@ describe(@"CMSocialAccountChooser", ^{
             [[theValue(answer) should] equal:theValue(NO)];
         }];
         
-        [chooser alertView:nil clickedButtonAtIndex:0];
+        [chooser alertView:[UIAlertView new] clickedButtonAtIndex:0];
     });
     
     it(@"should popup a uialert view (if it could) and say no", ^{
@@ -63,7 +63,7 @@ describe(@"CMSocialAccountChooser", ^{
             [[theValue(answer) should] equal:theValue(YES)];
         }];
         
-        [chooser alertView:nil clickedButtonAtIndex:1];
+        [chooser alertView:[UIAlertView new] clickedButtonAtIndex:1];
     });
 });
 

--- a/ios/iosTests/CMUserIntegrationSpec.m
+++ b/ios/iosTests/CMUserIntegrationSpec.m
@@ -56,10 +56,6 @@ describe(@"CMUser Integration", ^{
             [[expectFutureValue(mes) shouldEventually] beEmpty];
         });
         
-        it(@"should not have a current user", ^{
-            [[[CMUser currentUser] should] beNil];
-        });
-        
         it(@"should create an account with a username", ^{
             __block CMUserAccountResult code = NSNotFound;
             __block NSArray *mes = nil;
@@ -105,10 +101,6 @@ describe(@"CMUser Integration", ^{
             [[expectFutureValue(mes) shouldEventually] beEmpty];
         });
         
-        it(@"should now have a current user", ^{
-            [[[CMUser currentUser] should] beNonNil];
-        });
-        
         it(@"should successfully logout", ^{
             CMUser *user = [[CMUser alloc] initWithEmail:@"test@test.com" andPassword:@"testing"];
             
@@ -128,10 +120,6 @@ describe(@"CMUser Integration", ^{
             [[expectFutureValue(theValue(code)) shouldEventually] equal:@(CMUserAccountLogoutSucceeded)];
             [[expectFutureValue(user.token) shouldEventually] beNil];
             [[expectFutureValue(user.tokenExpiration) shouldEventually] beNil];
-        });
-        
-        it(@"should have no current user after a logout", ^{
-            [[[CMUser currentUser] should] beNil];
         });
         
         it(@"should fail to login when creating a bad account", ^{


### PR DESCRIPTION
A handful of changes to cleanup our test suite:

 * Suppressing warnings by satisfying nullability constraints added to Cocoa
 * Removing invalid, synchronous integration tests that failed non-deterministically
 * Avoiding a warning when building for testing by instantiating an otherwise uneeded object inside a preprocessor directive

Additionally, c3f4a13 removes the README from the build target, which was emitting a warning when building the framework.