### PR TITLE
Use a locally defined timeout for async integration test matchers

### DIFF
--- a/ios/iosTests/CMObjectIntegrationSpec.m
+++ b/ios/iosTests/CMObjectIntegrationSpec.m
@@ -66,9 +66,9 @@ describe(@"CMObject Integration", ^{
       [test1 save:^(CMObjectUploadResponse *response) {
         response1 = response;
       }];
-      [[expectFutureValue(response1) shouldEventually] beNonNil];
-      [[expectFutureValue(response1.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(5.0)] haveCountOf:1];
-      [[expectFutureValue(response1.uploadStatuses[objectID]) shouldEventuallyBeforeTimingOutAfter(5.0)] equal:@"created"];
+      [[expectFutureValue(response1) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+      [[expectFutureValue(response1.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+      [[expectFutureValue(response1.uploadStatuses[objectID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
     });
     
     it(@"should create multiple objects", ^{
@@ -88,8 +88,8 @@ describe(@"CMObject Integration", ^{
         response1 = response;
       }];
       
-      [[expectFutureValue(response1) shouldEventually] beNonNil];
-      [[expectFutureValue(response1.uploadStatuses) shouldEventually] haveLengthOf:6];
+      [[expectFutureValue(response1) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+      [[expectFutureValue(response1.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveLengthOf:6];
       
     });
     
@@ -110,8 +110,8 @@ describe(@"CMObject Integration", ^{
         //                }
       }];
       
-      [[expectFutureValue(objects) shouldEventually] beNonNil];
-      [[expectFutureValue(objects) shouldEventually] haveLengthOf:6];
+      [[expectFutureValue(objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+      [[expectFutureValue(objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveLengthOf:6];
       
     });
     
@@ -125,9 +125,9 @@ describe(@"CMObject Integration", ^{
       [test1.store replaceObject:test1 callback:^(CMObjectUploadResponse *response) {
         response1 = response;
       }];
-      [[expectFutureValue(response1) shouldEventually] beNonNil];
-      [[expectFutureValue(response1.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(5.0)] haveCountOf:1];
-      [[expectFutureValue(response1.uploadStatuses[objectID]) shouldEventuallyBeforeTimingOutAfter(5.0)] equal:@"updated"];
+      [[expectFutureValue(response1) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+      [[expectFutureValue(response1.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+      [[expectFutureValue(response1.uploadStatuses[objectID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"updated"];
     });
     
     context(@"User Level Objects", ^{
@@ -146,8 +146,8 @@ describe(@"CMObject Integration", ^{
           userStore.user = userObjects;
         }];
         
-        [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginSucceeded)];
-        [[expectFutureValue(mes) shouldEventually] beEmpty];
+        [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginSucceeded)];
+        [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
       });
       
       it(@"should create a user level object", ^{
@@ -159,8 +159,8 @@ describe(@"CMObject Integration", ^{
           
         }];
         
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventually] equal:@"created"];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
       });
       
       __block NSString *theID;
@@ -173,8 +173,8 @@ describe(@"CMObject Integration", ^{
           res = response;
         }];
         
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventually] equal:@"created"];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
         
       });
       
@@ -186,8 +186,8 @@ describe(@"CMObject Integration", ^{
           res = response;
         }];
         
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventually] equal:@"updated"];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"updated"];
       });
       
       it(@"should not save an object to both app and user level", ^{
@@ -204,10 +204,10 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventually] equal:@"created"];
-        [[expectFutureValue(res2.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(res2.error) shouldEventually] beNil];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(res.uploadStatuses[theID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
+        [[expectFutureValue(res2.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(res2.error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
       });
       
     });
@@ -238,9 +238,9 @@ describe(@"CMObject Integration", ^{
           
         }];
         
-        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventually] equal:@"created"];
-        [[expectFutureValue(theValue(owner.isLoggedIn)) shouldEventually] equal:@YES];
-        [[expectFutureValue(theValue(wantr.isLoggedIn)) shouldEventually] equal:@YES];
+        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
+        [[expectFutureValue(theValue(owner.isLoggedIn)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@YES];
+        [[expectFutureValue(theValue(wantr.isLoggedIn)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@YES];
       });
       
       
@@ -251,8 +251,8 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.acls) shouldEventually] beEmpty];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.acls) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
       });
       
       __block NSString *aclID = nil;
@@ -272,9 +272,9 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.error) shouldEventually] beNil];
-        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventually] equal:@"updated"];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"updated"];
       });
       
       it(@"should now let you get the ACL", ^{
@@ -283,9 +283,9 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.acls) shouldEventually] haveCountOf:1];
-        [[expectFutureValue([resp.acls.allObjects[0] objectId]) shouldEventually] equal:aclID];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.acls) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue([resp.acls.allObjects[0] objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:aclID];
       });
       
       it(@"should let the other user read the object", ^{
@@ -299,10 +299,10 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
         CMTestClass *testObject = [resp.objects lastObject];
-        [[expectFutureValue(testObject.objectId) shouldEventually] equal:testingID];
+        [[expectFutureValue(testObject.objectId) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:testingID];
       });
       
       it(@"should let you create a new object and add the same ACL to it", ^{
@@ -315,9 +315,9 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.error) shouldEventually] beNil];
-        [[expectFutureValue(resp.uploadStatuses[newObject.objectId]) shouldEventually] equal:@"created"];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+        [[expectFutureValue(resp.uploadStatuses[newObject.objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
       });
       
       it(@"should let the other user read both objects", ^{
@@ -331,8 +331,8 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:2];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:2];
       });
       
       it(@"should not let another user add ACL's to the object", ^{
@@ -358,10 +358,10 @@ describe(@"CMObject Integration", ^{
           
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(aclResponse.error.domain) shouldEventually] equal:CMErrorDomain];
-        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventually] equal:@(CMErrorInvalidRequest)];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(aclResponse.error.domain) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:CMErrorDomain];
+        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMErrorInvalidRequest)];
       });
       
       it(@"should immediately return the ACL's if you ask a shared object", ^{
@@ -382,10 +382,10 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(aclResponse) shouldEventually] beNonNil];
-        [[expectFutureValue(aclResponse.acls) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(aclResponse) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(aclResponse.acls) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
         [[newStore.webService shouldNot] receive:@selector(getACLsForUser:successHandler:errorHandler:)];
       });
       
@@ -401,8 +401,8 @@ describe(@"CMObject Integration", ^{
           resp = response;
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.uploadStatuses) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
       });
       
       it(@"should not let another user save the ACL's on the object", ^{
@@ -423,11 +423,11 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(aclResponse) shouldEventually] beNonNil];
-        [[expectFutureValue(aclResponse.error.domain) shouldEventually] equal:CMErrorDomain];
-        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventually] equal:@(CMErrorInvalidRequest)];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(aclResponse) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(aclResponse.error.domain) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:CMErrorDomain];
+        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMErrorInvalidRequest)];
         [[newStore.webService shouldNot] receive:@selector(updateACL:user:successHandler:errorHandler:)];
       });
       
@@ -449,11 +449,11 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(aclResponse) shouldEventually] beNonNil];
-        [[expectFutureValue(aclResponse.error.domain) shouldEventually] equal:CMErrorDomain];
-        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventually] equal:@(CMErrorInvalidRequest)];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(aclResponse) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(aclResponse.error.domain) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:CMErrorDomain];
+        [[expectFutureValue(theValue(aclResponse.error.code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMErrorInvalidRequest)];
         [[newStore.webService shouldNot] receive:@selector(updateValuesFromDictionary:serverSideFunction:user:extraParameters:successHandler:errorHandler:)];
       });
       
@@ -469,9 +469,9 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.uploadStatuses) shouldEventually] haveCountOf:1];
-        [[expectFutureValue(fetchResponse.acls) shouldEventually] beEmpty];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue(fetchResponse.acls) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
       });
       
       __block CMTestClass *newTest = nil;
@@ -495,9 +495,9 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(resp.error) shouldEventually] beNil];
-        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventually] equal:@"updated"];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(resp.error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+        [[expectFutureValue(resp.uploadStatuses[testingID]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"updated"];
       });
       
       it(@"should let anyone access a public object", ^{
@@ -515,8 +515,8 @@ describe(@"CMObject Integration", ^{
           }];
         }];
         
-        [[expectFutureValue(objects) shouldEventually] haveCountOf:1];
-        [[expectFutureValue([objects[0] objectId]) shouldEventually] equal:testingID];
+        [[expectFutureValue(objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+        [[expectFutureValue([objects[0] objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:testingID];
       });
     });
   });
@@ -549,7 +549,7 @@ describe(@"CMObject Integration", ^{
         res = response;
       }];
       
-      [[expectFutureValue(res) shouldEventually] beNonNil];
+      [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
     
     it(@"should fetch all objects near a point", ^{
@@ -562,7 +562,7 @@ describe(@"CMObject Integration", ^{
                     [[theValue(response.objects.count) should] equal:@10];
                   }];
       
-      [[expectFutureValue(res) shouldEventually] beNonNil];
+      [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
     
     it(@"should fetch 0 when asking from a random point", ^{
@@ -574,7 +574,7 @@ describe(@"CMObject Integration", ^{
                     [[theValue(response.objects.count) should] equal:@0];
                   }];
       
-      [[expectFutureValue(res) shouldEventually] beNonNil];
+      [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
     
     it(@"should fetch just a few when moved to a location nearby", ^{
@@ -586,7 +586,7 @@ describe(@"CMObject Integration", ^{
                     [[theValue(response.objects.count) should] equal:@1];
                   }];
       
-      [[expectFutureValue(res) shouldEventually] beNonNil];
+      [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
     
     it(@"should find everything in the default radius", ^{
@@ -598,7 +598,7 @@ describe(@"CMObject Integration", ^{
                     [[theValue(response.objects.count) should] equal:@10];
                   }];
       
-      [[expectFutureValue(res) shouldEventually] beNonNil];
+      [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
   });
 });

--- a/ios/iosTests/CMStoreIntegrationSpec.m
+++ b/ios/iosTests/CMStoreIntegrationSpec.m
@@ -45,9 +45,9 @@ describe(@"CMStoreIntegration", ^{
             res = response;
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.snippetResult.data) shouldEventually] beEmpty];
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.snippetResult.data) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
     });
     
     it(@"should allow the creation of another object and running a snippet", ^{
@@ -64,10 +64,10 @@ describe(@"CMStoreIntegration", ^{
             res = response;
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.snippetResult) shouldEventually] beNonNil];
-        [[expectFutureValue(res.snippetResult.data[@"store"]) shouldEventually] equal:@"integration"];
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.snippetResult) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.snippetResult.data[@"store"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"integration"];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
     });
     
     it(@"should be able to delete the venues", ^{
@@ -79,11 +79,11 @@ describe(@"CMStoreIntegration", ^{
         NSString *objectId1 = [venues[0] objectId];
         NSString *objectId2 = [venues[0] objectId];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.success) shouldEventually] haveCountOf:2];
-        [[expectFutureValue(res.success[objectId1]) shouldEventually] equal:@"deleted"];
-        [[expectFutureValue(res.success[objectId2]) shouldEventually] equal:@"deleted"];
-        [[expectFutureValue(res.objectErrors) shouldEventually] beEmpty];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.success) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:2];
+        [[expectFutureValue(res.success[objectId1]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"deleted"];
+        [[expectFutureValue(res.success[objectId2]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"deleted"];
+        [[expectFutureValue(res.objectErrors) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
     });
     
     it(@"should be able to save all objects", ^{
@@ -107,10 +107,10 @@ describe(@"CMStoreIntegration", ^{
         NSString *objectId1 = [venues[0] objectId];
         NSString *objectId2 = [venues[1] objectId];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:2];
-        [[expectFutureValue(res.uploadStatuses[objectId1]) shouldEventually] equal:@"created"];
-        [[expectFutureValue(res.uploadStatuses[objectId2]) shouldEventually] equal:@"created"];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:2];
+        [[expectFutureValue(res.uploadStatuses[objectId1]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
+        [[expectFutureValue(res.uploadStatuses[objectId2]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
     });
 
     it(@"should not throw an error if you try to save a nil object", ^{
@@ -136,9 +136,9 @@ describe(@"CMStoreIntegration", ^{
             res = response;
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.key) shouldEventually] beNonNil];
-        [[expectFutureValue(theValue(res.result)) shouldEventually] equal:@(CMFileCreated)];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.key) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(theValue(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMFileCreated)];
     });
     
     __block NSString *nonUserKey = @"app_icon_something";
@@ -150,9 +150,9 @@ describe(@"CMStoreIntegration", ^{
             res = response;
         }];
 
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.key) shouldEventually] equal:nonUserKey];
-        [[expectFutureValue(theValue(res.result)) shouldEventually] equal:@(CMFileCreated)];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.key) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:nonUserKey];
+        [[expectFutureValue(theValue(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMFileCreated)];
     });
     
     it(@"should fetch all the objects", ^{
@@ -163,8 +163,8 @@ describe(@"CMStoreIntegration", ^{
             [[ theValue([res.objects containsObject:venues[1]]) should] beTrue];
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.objects) shouldEventually] haveCountOfAtLeast:2];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOfAtLeast:2];
     });
     
     it(@"should fetch the obejcts by key", ^{
@@ -179,8 +179,8 @@ describe(@"CMStoreIntegration", ^{
             [[res.objects should] contain:v1];
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.objects) shouldEventually] haveCountOf:2];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:2];
     });
     
     it(@"should fetch all objects if the query is not specified", ^{
@@ -195,8 +195,8 @@ describe(@"CMStoreIntegration", ^{
             [[res.objects should] contain:v1];
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.objects) shouldEventually] haveCountOfAtLeast:2];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOfAtLeast:2];
     });
     
     it(@"should delete an object", ^{
@@ -207,8 +207,8 @@ describe(@"CMStoreIntegration", ^{
             res = response;
         }];
         
-        [[expectFutureValue(res) shouldEventually] beNonNil];
-        [[expectFutureValue(res.success) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(res.success) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
     });
     
     context(@"with a CMUser", ^{
@@ -220,7 +220,7 @@ describe(@"CMStoreIntegration", ^{
                 code = resultCode;
                 [store setUser:user];
             }];
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:@(CMUserAccountLoginSucceeded)];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMUserAccountLoginSucceeded)];
         });
         
         it(@"should allow the user to add objects", ^{
@@ -231,9 +231,9 @@ describe(@"CMStoreIntegration", ^{
             }];
             NSString *objectId1 = [venues[3] objectId];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(res.uploadStatuses[objectId1]) shouldEventually] equal:@"created"];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(res.uploadStatuses[objectId1]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"created"];
         });
         
         it(@"should allow the user to get the object by class", ^{
@@ -245,8 +245,8 @@ describe(@"CMStoreIntegration", ^{
                 [[fetched should] equal:venues[3]];
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.objects) shouldEventually] haveCountOf:1];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
         });
         
         it(@"should save all user objects with a save all", ^{
@@ -258,8 +258,8 @@ describe(@"CMStoreIntegration", ^{
                 called++;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(theValue(called)) shouldEventually] equal:@3];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(theValue(called)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@3];
         });
 
         it(@"should not throw an error when you attempt to save a nil user object", ^{
@@ -279,9 +279,9 @@ describe(@"CMStoreIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.key) shouldEventually] beNonNil];
-            [[expectFutureValue(theValue(res.result)) shouldEventually] equal:@(CMFileCreated)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.key) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(theValue(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMFileCreated)];
         });
         
         it(@"should let a user upload a file with a given key", ^{
@@ -292,9 +292,9 @@ describe(@"CMStoreIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.key) shouldEventually] beNonNil];
-            [[expectFutureValue(theValue(res.result)) shouldEventually] equal:@(CMFileCreated)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.key) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(theValue(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMFileCreated)];
         });
         
         it(@"should delete a user file", ^{
@@ -302,9 +302,9 @@ describe(@"CMStoreIntegration", ^{
             [store deleteUserFileNamed:@"my_wonderful_key" additionalOptions:nil callback:^(CMDeleteResponse *response) {
                 res = response;
             }];
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.success) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(res.success[@"my_wonderful_key"]) shouldEventually] equal:@"deleted"];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.success) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(res.success[@"my_wonderful_key"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"deleted"];
         });
         
         it(@"should fail to save any ACL's when none are passed", ^{
@@ -338,9 +338,9 @@ describe(@"CMStoreIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue(res.success) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(res.success[v.objectId]) shouldEventually] equal:@"deleted"];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(res.success) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(res.success[v.objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"deleted"];
         });
         
         context(@"with ACL's", ^{
@@ -355,7 +355,7 @@ describe(@"CMStoreIntegration", ^{
                     otherStore = [CMStore storeWithUser:aclUser];
                 }];
                 
-                [[expectFutureValue(theValue([newUser isLoggedIn])) shouldEventually] beTrue];
+                [[expectFutureValue(theValue([newUser isLoggedIn])) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beTrue];
                 
                 ///
                 /// Create an object for ACL testing
@@ -365,8 +365,8 @@ describe(@"CMStoreIntegration", ^{
                     res = response;
                 }];
                 
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(res.uploadStatuses) shouldEventually] haveCountOf:1];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(res.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
             });
             
             __block NSString *aclID = nil;
@@ -385,9 +385,9 @@ describe(@"CMStoreIntegration", ^{
                     res = response;
                 }];
                 
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(res.error) shouldEventually] beNil];
-                [[expectFutureValue(res.uploadStatuses[v.objectId]) shouldEventually] equal:@"updated"];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(res.error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+                [[expectFutureValue(res.uploadStatuses[v.objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"updated"];
             });
             
             it(@"should add the ACL when a user fetches the objects", ^{
@@ -401,8 +401,8 @@ describe(@"CMStoreIntegration", ^{
                     [[[v valueForKey:@"sharedACL"] shouldNot] beNil];
                 }];
                 
-                [[expectFutureValue(resp) shouldEventually] beNonNil];
-                [[expectFutureValue(resp.objects) shouldEventually] haveCountOf:1];
+                [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(resp.objects) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
             });
             
             it(@"should allow the user to search for ACL's", ^{
@@ -413,9 +413,9 @@ describe(@"CMStoreIntegration", ^{
                     res = response;
                 }];
 
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(res.acls) shouldEventually] beEmpty];
-                [[expectFutureValue([res permissionsForMember:aclUser.objectId]) shouldEventually] beEmpty];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(res.acls) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+                [[expectFutureValue([res permissionsForMember:aclUser.objectId]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
             });
             
             it(@"should delete the ACL", ^{
@@ -424,8 +424,8 @@ describe(@"CMStoreIntegration", ^{
                     res = response;
                 }];
                 
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(res.success) shouldEventually] haveCountOf:1];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(res.success) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
             });
         });
         

--- a/ios/iosTests/CMUserIntegrationSpec.m
+++ b/ios/iosTests/CMUserIntegrationSpec.m
@@ -18,11 +18,6 @@
 
 SPEC_BEGIN(CMUserIntegrationSpec)
 
-///
-/// If this assertion fails, command click the macro, and change the default to 2.0
-///
-//assert(kKW_DEFAULT_PROBE_TIMEOUT == 2.0);
-
 describe(@"CMUser Integration", ^{
     
     beforeAll(^{
@@ -35,7 +30,7 @@ describe(@"CMUser Integration", ^{
         [[CMUser currentUser] logoutWithCallback:^(CMUserAccountResult resultCode, NSArray *messages) {
             code = resultCode;
         }];
-        [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLogoutSucceeded)];
+        [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLogoutSucceeded)];
     });
     
     context(@"given a real user", ^{
@@ -52,8 +47,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCreateSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCreateSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should create an account with a username", ^{
@@ -66,8 +61,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCreateSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCreateSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fail to create an account with the same username", ^{
@@ -80,8 +75,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCreateFailedDuplicateAccount)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCreateFailedDuplicateAccount)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should successfully login them in", ^{
@@ -95,10 +90,10 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginSucceeded)];
-            [[expectFutureValue(user.token) shouldEventually] beNonNil];
-            [[expectFutureValue(user.tokenExpiration) shouldEventually] beNonNil];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginSucceeded)];
+            [[expectFutureValue(user.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(user.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should successfully logout", ^{
@@ -117,9 +112,9 @@ describe(@"CMUser Integration", ^{
                 }];
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:@(CMUserAccountLogoutSucceeded)];
-            [[expectFutureValue(user.token) shouldEventually] beNil];
-            [[expectFutureValue(user.tokenExpiration) shouldEventually] beNil];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMUserAccountLogoutSucceeded)];
+            [[expectFutureValue(user.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(user.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
         });
         
         it(@"should fail to login when creating a bad account", ^{
@@ -132,10 +127,10 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:@(CMUserAccountCreateFailedInvalidRequest)];
-            [[expectFutureValue(user.token) shouldEventually] beNil];
-            [[expectFutureValue(user.tokenExpiration) shouldEventually] beNil];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMUserAccountCreateFailedInvalidRequest)];
+            [[expectFutureValue(user.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(user.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fail to login with the wrong credentials", ^{
@@ -148,8 +143,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginFailedIncorrectCredentials)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginFailedIncorrectCredentials)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fail to save the user when they are not logged in", ^{
@@ -178,8 +173,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginFailedIncorrectCredentials)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginFailedIncorrectCredentials)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should create the user on a save if they haven't been created", ^{
@@ -192,8 +187,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCreateSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCreateSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         __block CMUser *testUser = nil;
@@ -209,10 +204,10 @@ describe(@"CMUser Integration", ^{
                 testUser = user;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginSucceeded)];
-            [[expectFutureValue(user.token) shouldEventually] beNonNil];
-            [[expectFutureValue(user.tokenExpiration) shouldEventually] beNonNil];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginSucceeded)];
+            [[expectFutureValue(user.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(user.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should login the user if they have the correct username set", ^{
@@ -228,10 +223,10 @@ describe(@"CMUser Integration", ^{
                 }];
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
-            [[expectFutureValue(testUser.token) shouldEventually] beNonNil];
-            [[expectFutureValue(testUser.tokenExpiration) shouldEventually] beNonNil];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
+            [[expectFutureValue(testUser.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(testUser.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should let the user save", ^{
@@ -243,8 +238,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fetch the user's profile", ^{
@@ -256,8 +251,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] haveLengthOf:1];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveLengthOf:1];
         });
         
         it(@"should change the password", ^{
@@ -269,10 +264,10 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountPasswordChangeSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
-            [[expectFutureValue(testUser.token) shouldEventually] beNonNil];
-            [[expectFutureValue(testUser.tokenExpiration) shouldEventually] beNonNil];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountPasswordChangeSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(testUser.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(testUser.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
         });
         
         it(@"should change the email", ^{
@@ -282,10 +277,10 @@ describe(@"CMUser Integration", ^{
                 code = resultCode;
                 mes = messages;
             }];
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountEmailChangeSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
-            [[expectFutureValue(testUser.token) shouldEventually] beNonNil];
-            [[expectFutureValue(testUser.tokenExpiration) shouldEventually] beNonNil];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountEmailChangeSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(testUser.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(testUser.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
             [[expectFutureValue(testUser.email) should] equal:@"test_new_email@test.com"];
         });
         
@@ -300,10 +295,10 @@ describe(@"CMUser Integration", ^{
                 code = resultCode;
                 mes = messages;
             }];
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountUsernameChangeSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
-            [[expectFutureValue(testUser.token) shouldEventually] beNonNil];
-            [[expectFutureValue(testUser.tokenExpiration) shouldEventually] beNonNil];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountUsernameChangeSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(testUser.token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(testUser.tokenExpiration) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
             [[expectFutureValue(testUser.username) should] equal:@"NewUsername"];
         });
         
@@ -321,9 +316,9 @@ describe(@"CMUser Integration", ^{
                 code = resultCode;
                 mes = messages;
             }];
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountEmailChangeSucceeded)];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountEmailChangeSucceeded)];
 #pragma clang diagnostic pop
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should change the username, email, and password", ^{
@@ -339,8 +334,8 @@ describe(@"CMUser Integration", ^{
                                                    code = resultCode;
                                                    mes = messages;
                                                }];
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCredentialChangeSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCredentialChangeSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should change the username, userid (email) and password", ^{
@@ -359,10 +354,10 @@ describe(@"CMUser Integration", ^{
                                                    mes = messages;
                                                }];
 #pragma clang diagnostic pop
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountCredentialChangeSucceeded)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
-            [[expectFutureValue(testUser.email) shouldEventually] equal:@"thisisemail@test.com"];
-            [[expectFutureValue(testUser.username) shouldEventually] equal:@"HowManyToDo"];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountCredentialChangeSucceeded)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(testUser.email) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"thisisemail@test.com"];
+            [[expectFutureValue(testUser.username) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"HowManyToDo"];
 
         });
         
@@ -383,8 +378,8 @@ describe(@"CMUser Integration", ^{
                     mes = messages;
                 }];
                 
-                [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginSucceeded)];
-                [[expectFutureValue(mes) shouldEventually] beEmpty];
+                [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginSucceeded)];
+                [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
             });
             
             it(@"should fetch the user's profile", ^{
@@ -398,8 +393,8 @@ describe(@"CMUser Integration", ^{
                     [[mes[0][@"lastName"] should] equal:@"Mick"];
                 }];
                 
-                [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
-                [[expectFutureValue(mes) shouldEventually] haveLengthOf:1];
+                [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountProfileUpdateSucceeded)];
+                [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveLengthOf:1];
             });
         });
         
@@ -428,8 +423,8 @@ describe(@"CMUser Integration", ^{
                     cardUser = user;
                 }];
                 
-                [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountLoginSucceeded)];
-                [[expectFutureValue(mes) shouldEventually] beEmpty];
+                [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountLoginSucceeded)];
+                [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
             });
             
             it(@"should add a card", ^{
@@ -438,11 +433,11 @@ describe(@"CMUser Integration", ^{
                     res = response;
                 }];
                 
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(@(res.result)) shouldEventually] equal:@(CMPaymentResultSuccessful)];
-                [[expectFutureValue(@(res.httpResponseCode)) shouldEventually] equal:@(200)];
-                [[expectFutureValue(res.errors) shouldEventually] beEmpty];
-                [[expectFutureValue(res.body[@"added"]) shouldEventually] equal:@(0)];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(@(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMPaymentResultSuccessful)];
+                [[expectFutureValue(@(res.httpResponseCode)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(200)];
+                [[expectFutureValue(res.errors) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+                [[expectFutureValue(res.body[@"added"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(0)];
             });
             
             it(@"should fetch the payment methods", ^{
@@ -450,13 +445,13 @@ describe(@"CMUser Integration", ^{
                 [cardUser paymentMethods:^(CMPaymentResponse *response) {
                     res = response;
                 }];
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(@(res.result)) shouldEventually] equal:@(CMPaymentResultSuccessful)];
-                [[expectFutureValue(@(res.httpResponseCode)) shouldEventually] equal:@(200)];
-                [[expectFutureValue(res.errors) shouldEventually] beEmpty];
-                [[expectFutureValue(res.body) shouldEventually] haveCountOf:1];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(@(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMPaymentResultSuccessful)];
+                [[expectFutureValue(@(res.httpResponseCode)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(200)];
+                [[expectFutureValue(res.errors) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+                [[expectFutureValue(res.body) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
                 
-                [[expectFutureValue(((CMCardPayment *)res.body[0]).token) shouldEventually] equal:@"3243249390328409"];
+                [[expectFutureValue(((CMCardPayment *)res.body[0]).token) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"3243249390328409"];
             });
             
             it(@"should let you remove a payment method", ^{
@@ -464,11 +459,11 @@ describe(@"CMUser Integration", ^{
                 [cardUser removePaymentMethodAtIndex:0 callback:^(CMPaymentResponse *response) {
                     res = response;
                 }];
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(@(res.result)) shouldEventually] equal:@(CMPaymentResultSuccessful)];
-                [[expectFutureValue(@([res wasSuccess])) shouldEventually] equal:@(YES)];
-                [[expectFutureValue(res.errors) shouldEventually] beEmpty];
-                [[expectFutureValue(res.body) shouldEventually] haveCountOf:1];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(@(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMPaymentResultSuccessful)];
+                [[expectFutureValue(@([res wasSuccess])) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(YES)];
+                [[expectFutureValue(res.errors) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+                [[expectFutureValue(res.body) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
             });
             
             it(@"fetching payment methods again should return nothing", ^{
@@ -476,11 +471,11 @@ describe(@"CMUser Integration", ^{
                 [cardUser paymentMethods:^(CMPaymentResponse *response) {
                     res = response;
                 }];
-                [[expectFutureValue(res) shouldEventually] beNonNil];
-                [[expectFutureValue(@(res.result)) shouldEventually] equal:@(CMPaymentResultSuccessful)];
-                [[expectFutureValue(@(res.httpResponseCode)) shouldEventually] equal:@(200)];
-                [[expectFutureValue(res.errors) shouldEventually] beEmpty];
-                [[expectFutureValue(res.body) shouldEventually] haveCountOf:0];
+                [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+                [[expectFutureValue(@(res.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMPaymentResultSuccessful)];
+                [[expectFutureValue(@(res.httpResponseCode)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(200)];
+                [[expectFutureValue(res.errors) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+                [[expectFutureValue(res.body) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:0];
             });
             
         });
@@ -503,9 +498,9 @@ describe(@"CMUser Integration", ^{
                 error = errors;
             }];
             
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] beNonNil];
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] haveCountOf:10];
-            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(4.0)] beEmpty];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:10];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should find all users when given no query or identifier", ^{
@@ -518,9 +513,9 @@ describe(@"CMUser Integration", ^{
                 error = response.error;
             }];
             
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] beNonNil];
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] haveCountOf:10];
-            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(4.0)] beNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:10];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
         });
         
         it(@"should return the count of users", ^{
@@ -536,9 +531,9 @@ describe(@"CMUser Integration", ^{
                 [[theValue(response.count) should] equal:theValue(10)];
             }];
             
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] beNonNil];
-            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(4.0)] haveCountOf:5];
-            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(4.0)] beNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:5];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
         });
         
         __block NSString *identifier = nil;
@@ -556,10 +551,10 @@ describe(@"CMUser Integration", ^{
                 }
             }];
             
-            [[expectFutureValue(all) shouldEventually] beNonNil];
-            [[expectFutureValue(all) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(error) shouldEventually] beEmpty];
-            [[expectFutureValue(((CMUser *)all[0]).email) shouldEventually] equal:@"testcard@cloudmine.me"];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(((CMUser *)all[0]).email) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"testcard@cloudmine.me"];
         });
         
         identifier = nil;
@@ -577,10 +572,10 @@ describe(@"CMUser Integration", ^{
                 }
             }];
 
-            [[expectFutureValue(all) shouldEventually] beNonNil];
-            [[expectFutureValue(all) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(error) shouldEventually] beNil];
-            [[expectFutureValue(((CMUser *)all[0]).email) shouldEventually] equal:@"testcard@cloudmine.me"];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(((CMUser *)all[0]).email) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"testcard@cloudmine.me"];
         });
 
         
@@ -601,10 +596,10 @@ describe(@"CMUser Integration", ^{
                 }
             }];
             
-            [[expectFutureValue(all) shouldEventually] beNonNil];
-            [[expectFutureValue(all) shouldEventually] haveCountOf:1];
-            [[expectFutureValue(error) shouldEventually] beEmpty];
-            [[[CMWebService sharedWebService] shouldNotEventually] receive:@selector(getUserProfileWithIdentifier:callback:)];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(all) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
+            [[expectFutureValue(error) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[[CMWebService sharedWebService] shouldNotEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] receive:@selector(getUserProfileWithIdentifier:callback:)];
         });
     });
     
@@ -624,8 +619,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountOperationFailedUnknownAccount)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountOperationFailedUnknownAccount)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fail to logout the user", ^{
@@ -640,8 +635,8 @@ describe(@"CMUser Integration", ^{
                 mes = messages;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:theValue(CMUserAccountOperationFailedUnknownAccount)];
-            [[expectFutureValue(mes) shouldEventually] beEmpty];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMUserAccountOperationFailedUnknownAccount)];
+            [[expectFutureValue(mes) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
         });
         
         it(@"should fail to fetch the profile", ^{
@@ -653,8 +648,8 @@ describe(@"CMUser Integration", ^{
                 err = errors;
             }];
             
-            [[expectFutureValue(use) shouldEventually] beEmpty];
-            [[expectFutureValue(err) shouldEventually] beNil];
+            [[expectFutureValue(use) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beEmpty];
+            [[expectFutureValue(err) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
         });
     });
 
@@ -691,7 +686,7 @@ describe(@"CMUser Integration", ^{
                                      [[theValue(response.user.isLoggedIn) should] beYes];
                                  }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
         });
         
         it(@"should let the user add another social account natively", ^{
@@ -721,7 +716,7 @@ describe(@"CMUser Integration", ^{
                                      [[theValue(response.user.isLoggedIn) should] beYes];
                                  }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
         });
         
     });

--- a/ios/iosTests/CMWebServiceIntegrationSpec.m
+++ b/ios/iosTests/CMWebServiceIntegrationSpec.m
@@ -38,9 +38,9 @@ describe(@"CMWebServiceIntegration", ^{
                 err = error;
             }];
             
-            [[expectFutureValue(result) shouldEventually] beNonNil];
-            [[expectFutureValue(err) shouldEventually] beNil];
-            [[expectFutureValue(result[@"store"]) shouldEventually] equal:@"integration"];
+            [[expectFutureValue(result) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(err) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(result[@"store"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"integration"];
         });
         
         it(@"should correctly send parameters to the snippet", ^{
@@ -53,9 +53,9 @@ describe(@"CMWebServiceIntegration", ^{
                 err = error;
             }];
             
-            [[expectFutureValue(result) shouldEventually] beNonNil];
-            [[expectFutureValue(err) shouldEventually] beNil];
-            [[expectFutureValue(result[@"params"][@"my_param"]) shouldEventually] equal:@"15"];
+            [[expectFutureValue(result) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(err) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(result[@"params"][@"my_param"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"15"];
         });
         
         it(@"should correctly run a POST snippet", ^{
@@ -72,9 +72,9 @@ describe(@"CMWebServiceIntegration", ^{
                 err = error;
             }];
             
-            [[expectFutureValue(result) shouldEventually] beNonNil];
-            [[expectFutureValue(err) shouldEventually] beNil];
-            [[expectFutureValue(result[@"data"][@"some_data"]) shouldEventually] equal:@"hello"];
+            [[expectFutureValue(result) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(err) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(result[@"data"][@"some_data"]) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@"hello"];
         });
     });
 
@@ -123,7 +123,7 @@ describe(@"CMWebServiceIntegration", ^{
                 code = resultCode;
             }];
             
-            [[expectFutureValue(theValue(code)) shouldEventually] equal:@(CMUserAccountLoginSucceeded)];
+            [[expectFutureValue(theValue(code)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMUserAccountLoginSucceeded)];
             
             __block NSDictionary *result = nil;
             __block NSError *err = nil;
@@ -135,9 +135,9 @@ describe(@"CMWebServiceIntegration", ^{
                 err = error;
             }];
             
-            [[expectFutureValue(result) shouldEventually] beNonNil];
-            [[expectFutureValue(err) shouldEventually] beNil];
-            [[expectFutureValue(channelName) shouldEventually] beNonNil];
+            [[expectFutureValue(result) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue(err) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNil];
+            [[expectFutureValue(channelName) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
         });
         
         it(@"should fail to unregister a token when none is registered", ^{
@@ -147,7 +147,7 @@ describe(@"CMWebServiceIntegration", ^{
                 res = result;
             }];
             
-            [[expectFutureValue(theValue(res)) shouldEventually] equal:@(CMDeviceTokenOperationFailed)];
+            [[expectFutureValue(theValue(res)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceTokenOperationFailed)];
         });
         
         it(@"should let the user upload a device token", ^{
@@ -159,7 +159,7 @@ describe(@"CMWebServiceIntegration", ^{
                 res = result;
             }];
             
-            [[expectFutureValue(theValue(res)) shouldEventually] equal:@(CMDeviceTokenUploadSuccess)];
+            [[expectFutureValue(theValue(res)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceTokenUploadSuccess)];
         });
         
         it(@"should let the user upload the token again and get a 200", ^{
@@ -171,7 +171,7 @@ describe(@"CMWebServiceIntegration", ^{
                 res = result;
             }];
             
-            [[expectFutureValue(theValue(res)) shouldEventually] equal:@(CMDeviceTokenUpdated)];
+            [[expectFutureValue(theValue(res)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceTokenUpdated)];
         });
         
         it(@"should get the push channels", ^{
@@ -180,8 +180,8 @@ describe(@"CMWebServiceIntegration", ^{
             [service getChannelsForThisDeviceWithCallback:^(CMViewChannelsResponse *response) {
                 res = response;
             }];
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMViewChannelsRequestSucceeded)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMViewChannelsRequestSucceeded)];
         });
         
         it(@"should fail to subscribe a device to a non-existant channel", ^{
@@ -191,8 +191,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceChannelOperationFailed)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceChannelOperationFailed)];
         });
         
         it(@"should subscribe a device to a channel", ^{
@@ -202,8 +202,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceAddedToChannel)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceAddedToChannel)];
         });
         
         it(@"should subscribe another device to a channel", ^{
@@ -212,8 +212,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceAddedToChannel)]; //no device so it fails
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceAddedToChannel)]; //no device so it fails
         });
         
         it(@"should subscribe a user to a channel", ^{
@@ -223,8 +223,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceAddedToChannel)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceAddedToChannel)];
         });
         
         it(@"should unsubscribe this device from a channel", ^{
@@ -234,8 +234,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceRemovedFromChannel)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceRemovedFromChannel)];
         });
         
         it(@"should unsubscribe another device from a channel", ^{
@@ -245,8 +245,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceRemovedFromChannel)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceRemovedFromChannel)];
         });
         
         it(@"should unsubscribe a user from a channel", ^{
@@ -256,8 +256,8 @@ describe(@"CMWebServiceIntegration", ^{
                 res = response;
             }];
             
-            [[expectFutureValue(res) shouldEventually] beNonNil];
-            [[expectFutureValue( theValue(res.result) ) shouldEventually] equal:@(CMDeviceRemovedFromChannel)];
+            [[expectFutureValue(res) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+            [[expectFutureValue( theValue(res.result) ) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceRemovedFromChannel)];
         });
         
         it(@"should let the user unregister a token", ^{
@@ -267,7 +267,7 @@ describe(@"CMWebServiceIntegration", ^{
                 res = result;
             }];
             
-            [[expectFutureValue(theValue(res)) shouldEventually] equal:@(CMDeviceTokenDeleted)];
+            [[expectFutureValue(theValue(res)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:@(CMDeviceTokenDeleted)];
         });
         
     });

--- a/ios/iosTests/IOS-29Spec.m
+++ b/ios/iosTests/IOS-29Spec.m
@@ -8,6 +8,7 @@
 
 #import "Kiwi.h"
 #import "CMObject.h"
+#import "CMTestMacros.h"
 
 @interface IOS29 : CMObject
 
@@ -63,7 +64,7 @@ describe(@"CMObject Bug", ^{
             resp = response;
         }];
         
-        [[expectFutureValue(resp.uploadStatuses) shouldEventually] haveCountOf:1];
+        [[expectFutureValue(resp.uploadStatuses) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] haveCountOf:1];
     });
     
     

--- a/ios/iosTests/Support/CMTestMacros.h
+++ b/ios/iosTests/Support/CMTestMacros.h
@@ -14,3 +14,5 @@
 
 #define BASE_URL (((NSString *)[[NSProcessInfo processInfo] environment][@"BASE_URL"]).length != 0 ? [[NSProcessInfo processInfo] environment][@"BASE_URL"] : CM_BASE_URL)
 
+
+#define CM_TEST_TIMEOUT 10.0

--- a/ios/iosTests/UIImageWithCloudMineIntegrationSpec.m
+++ b/ios/iosTests/UIImageWithCloudMineIntegrationSpec.m
@@ -40,22 +40,22 @@ describe(@"UIImageWithCloudMineIntegrationSpec", ^{
             NSLog(@"Key? %@", key);
         }];
         
-        [[expectFutureValue(resp) shouldEventually] beNonNil];
-        [[expectFutureValue(theValue(resp.result)) shouldEventually] equal:theValue(CMFileCreated)];
-        [[expectFutureValue(key) shouldEventually] beNonNil];
+        [[expectFutureValue(resp) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
+        [[expectFutureValue(theValue(resp.result)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:theValue(CMFileCreated)];
+        [[expectFutureValue(key) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
         
         __block CMFileUploadResponse *resp2 = nil;
         [store saveFileWithData:UIImagePNGRepresentation(image) named:@"second" additionalOptions:nil callback:^(CMFileUploadResponse *response) {
             resp2 = response;
         }];
-        [[expectFutureValue(resp2) shouldEventually] beNonNil];
+        [[expectFutureValue(resp2) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] beNonNil];
     });
     
     it(@"should be able to set the image to a UIImageView with just the key", ^{
         
         UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 10, 10)];
         [imageView setImageWithFileKey:key];
-        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventually] equal:UIImagePNGRepresentation(image)];
+        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:UIImagePNGRepresentation(image)];
     });
     
     it(@"should immediatly set a placeholder iamge", ^{
@@ -66,7 +66,7 @@ describe(@"UIImageWithCloudMineIntegrationSpec", ^{
         [imageView setImageWithFileKey:@"second" placeholderImage:placeholder];
         [[imageView.image shouldNot] beNil];
         [[UIImagePNGRepresentation(imageView.image) should] equal:UIImagePNGRepresentation(placeholder)];
-        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventually] equal:UIImagePNGRepresentation(image)];
+        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:UIImagePNGRepresentation(image)];
     });
     
     it(@"should cache the image we retrived and use it immediatly", ^{
@@ -94,7 +94,7 @@ describe(@"UIImageWithCloudMineIntegrationSpec", ^{
             }];
         }];
         
-        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventuallyBeforeTimingOutAfter(5.0)] equal:UIImagePNGRepresentation(image)];
+        [[expectFutureValue(UIImagePNGRepresentation(imageView.image)) shouldEventuallyBeforeTimingOutAfter(CM_TEST_TIMEOUT)] equal:UIImagePNGRepresentation(image)];
     });
     
 });


### PR DESCRIPTION
Converts all integration test matchers to use the Kiwi macro which specifies a timeout specifically. A constant is defined to accomplish this so timeout value of all tests can be changed at once.

The default in Kiwi is only 1 second, which causes random test failures on all but the best connections. The timeout of 10 seconds does *not* mean each integration test has to wait 10 seconds. The test will proceed as soon as the result comes back from the server.