### PR TITLE
Fix type cast warning exposed by Xcode 8

### DIFF
--- a/ios/ios/src/Storage/CMStore.m
+++ b/ios/ios/src/Storage/CMStore.m
@@ -274,7 +274,7 @@ NSString * const CMStoreObjectDeletedNotification = @"CMStoreObjectDeletedNotifi
         return;
     }
 
-    CMAppDelegateBase *delegate = [[UIApplication sharedApplication] delegate];
+    CMAppDelegateBase *delegate = (CMAppDelegateBase *)[[UIApplication sharedApplication] delegate];
     delegate.callback = callback;
     delegate.user = aUser;
     delegate.service = self.webService;


### PR DESCRIPTION
No effect on behavior; was already being checked with `NSAssert` but for whatever reason, Xcode 8 started showing a warning where previous versions never did.