### PR TITLE
Work around KVC Crasher in CMObject -description method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.7.13 (September 26, 2016)
+===========================
+Bugfixes:
+  * Resolve a compiler warning caused by stricter Objective-C casting rules in Xcode 8
+  * Fix a bug in the CMObject -description method that could, in rare circumstances, cause a crash
+
 1.7.12 (August 9, 2016)
 ======================
 Bugfixes:
@@ -30,7 +36,7 @@ v1.7.5 (June 12, 2015)
 v1.7.5 (March 6, 2015)
 ======================
 * Changed all returned values to be `instancetype`
-* Fixed a bug in which a dictionary that looked like a CMObject, but shouldn't be, was deserialized to be a CMUntypedObject. Inserting `__class__: 'map'` as a Key/Value pair in your dictionaries will stop this from occuring.
+* Fixed a bug in which a dictionary that looked like a CMObject, but shouldn't be, was deserialized to be a CMUntypedObject. Inserting `__class__: 'map'` as a Key/Value pair in your dictionaries will stop this from occurring.
 
 v1.7.4 (March 5, 2015)
 ======================

--- a/CloudMine.podspec
+++ b/CloudMine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CloudMine"
-  s.version      = "1.7.12"
+  s.version      = "1.7.13"
   s.summary      = "The iOS Framework for interacting with CloudMine."
   s.homepage     = "https://cloudmine.io/docs/#/ios"
   s.license      = 'MIT'

--- a/ios/cloudmine-ios.xcodeproj/project.pbxproj
+++ b/ios/cloudmine-ios.xcodeproj/project.pbxproj
@@ -1420,7 +1420,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EE1B44A5F6B4AA8E61850EFA /* Pods-cloudmine-ios.debug.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.7.12;
+				CURRENT_PROJECT_VERSION = 1.7.13;
 				DSTROOT = /tmp/ios.dst;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
@@ -1448,7 +1448,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2A33E73BEDE10A94973E9FE /* Pods-cloudmine-ios.release.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.7.12;
+				CURRENT_PROJECT_VERSION = 1.7.13;
 				DSTROOT = /tmp/ios.dst;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
@@ -1574,7 +1574,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C3444874F77B35F0544725D1 /* Pods-cloudmine-ios.test.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 1.7.12;
+				CURRENT_PROJECT_VERSION = 1.7.13;
 				DSTROOT = /tmp/ios.dst;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;

--- a/ios/ios/src/CMConstants.h
+++ b/ios/ios/src/CMConstants.h
@@ -16,6 +16,6 @@
 
 #define CM_DEFAULT_API_VERSION @"v1"
 
-#define CM_VERSION @"1.7.12"
+#define CM_VERSION @"1.7.13"
 
 #endif

--- a/ios/ios/src/Persisted Objects/CMObject.m
+++ b/ios/ios/src/Persisted Objects/CMObject.m
@@ -365,11 +365,24 @@
     
     for (RTProperty *prop in properties) {
         if (!([prop.name isEqualToString:@"description"] || [prop.name isEqualToString:@"debugDescription"] )) {
-            string = [string stringByAppendingFormat:@"\n%@: %@", prop.name, [self valueForKey:prop.name]];
+            string = [string stringByAppendingFormat:@"\n%@: %@", prop.name, [self safe_valueForKey:prop.name]];
         }
     }
     
     return string;
+}
+
+- (NSString *)safe_valueForKey:(NSString *)key
+{
+    NSString *value = @"";
+
+    @try {
+        value = [self valueForKey:key];
+    } @catch (NSException *exception) {
+        value = exception.name;
+    } @finally {
+        return value;
+    }
 }
 
 @end

--- a/ios/iosTests/cloudmine-iosTests-Info.plist
+++ b/ios/iosTests/cloudmine-iosTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.11</string>
+	<string>1.7.13</string>
 </dict>
 </plist>


### PR DESCRIPTION
**NOTE:** Merge after #80 

A customer reports a low but non-negligible crash rate from
CMObject's -description method. The method throws a
NSUndefinedKeyException in rare circumstances, which we can not
reproduce. The key being called is one observed dynamically by
the MAObjCRuntime library. This is the most conservative fix:
in this method only, we call a "safe" version of valueForKey: which
wraps the call in a @try-@catch block.

A more aggressive fix would have been to override -valueForUndefinedKey:
on CMObject, but given the runtime trickery used throughout the app,
I can't feel 100% confident there would be no other side effects in
doing so. There have been other places in the SDK where @try-@catch had
been used for actual control flow.

The *ideal* fix would be to track down why the RT lib is returning a
property  name that subsequently results in an undefined key exception.
Given the low incedence and the fact its coming from a non-critical
code path, investing that time seems overkill for now.