### PR TITLE
Fixing memory leak with "__bridge"

### DIFF
--- a/ios/ios/src/Extensions/CMTools.m
+++ b/ios/ios/src/Extensions/CMTools.m
@@ -12,27 +12,26 @@
 
 + (NSString *)urlEncode:(NSString *)string;
 {
-    CFStringRef ret = CFURLCreateStringByAddingPercentEscapes(
+    NSString* ret = (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(
                                                               kCFAllocatorDefault,
                                                               (CFStringRef)string,
                                                               NULL,
                                                               (CFStringRef)@";/?:@&=+$,",
                                                               kCFStringEncodingUTF8
                                                               );
-    return (__bridge NSString *)(ret);
+    return ret;
 }
 
 + (NSString *)urlEncodeButLeaveQuery:(NSString *)string;
 {
-    CFStringRef ret = CFURLCreateStringByAddingPercentEscapes(
+    NSString* ret = (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(
                                                               kCFAllocatorDefault,
                                                               (CFStringRef)string,
                                                               NULL,
                                                               (CFStringRef)@";/:@+$,",
                                                               kCFStringEncodingUTF8
                                                               );
-    return (__bridge NSString *)(ret);
-    
+    return ret;
 }
 
 


### PR DESCRIPTION
In my app, I got memory leaks when Cloudmine SDK uses CMTools. So, I just change object to NS object, which fully supported by ARC and this solve problem.